### PR TITLE
fix: Correct Panache list method usage in PostResource

### DIFF
--- a/microblog-api/src/main/kotlin/com/microblog/api/post/PostResource.kt
+++ b/microblog-api/src/main/kotlin/com/microblog/api/post/PostResource.kt
@@ -81,7 +81,7 @@ class PostResource {
 
         val posts = Post.find("authorId", userId)
             .page(offset / limit, limit) // Panache page index is 0-based
-            .list<Post>()
+            .list()
 
         val postDTOs = posts.map { post ->
             // For multiple posts, fetching each author individually can be N+1.


### PR DESCRIPTION
Remove explicit type argument from .list() call as it's inferred and not standard Panache syntax.